### PR TITLE
Add httpRequests to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 **/.idea/**/tasks.xml
 **/.idea/shelf/*
 **/.idea/dictionaries
+**/.idea/httpRequests/
 
 # Sensitive or high-churn files
 **/.idea/**/dataSources/


### PR DESCRIPTION
Is it correct that those editor-based HTTP client requests are user specific? Rider (sometimes but not always) adds this to `.idea/.gitgnore` automatically.