### PR TITLE
Translate to Japanese 00-EssentialShortcuts

### DIFF
--- a/localized/ja/00-EssentialShortcuts/0.0-Shortcuts.md
+++ b/localized/ja/00-EssentialShortcuts/0.0-Shortcuts.md
@@ -1,16 +1,27 @@
-# Shortcuts And Actions
+# 必須ショートカット機能の習得
 
-Through out this guided experience, you will see "shortcut" tags. 
-These tags include the official name of each action and can be found
-using the the `Find Action...` feature of your IDE. Reference your
-preferences to find out what that shortcut is, but here are a few known
-shortcut combinations: 
+この演習では ReSharper や Rider が提供する機能のうち、必須で習得して欲しい機能を学びます。
+この必須機能は、ショートカットで簡単、かつ、ダイレクトに呼び出すことが出来ます。
+
+ショートカットキーはたくさんありますが、困ったら検索することが出来ます。
+困った時に探す方法を紹介するので、後述するチートシートを印刷して、マーカーを引いておくことを推奨します。
+
+
+## ショートカットキーと機能
+
+`Find Action...` の機能を使うと、たくさんあるショートカットキーに割り当てられた機能を見つけ出すことが出来ます。ショートカットキーの設定はいくつかの代表的な設定があります。自分がどの設定を使っているか、InstallしたReSharper や Rider の Preferences (設定) を確認してください。
+
+`Find Action...` の機能を呼び出す代表的なショートカットキーは以下の通りです:
 
 - ReSharper Keymap on Windows: `Ctrl + Shift + A`
 - Visual Studio Keymap on Windows: `Ctrl + Shift + A`
 - Visual Studio Keymap on macOS: `Command (⌘) + Shift (⇧) + A`
 
-The Keymap reference guide is also available online :
+ショートカットキーのチートシートがあります。
+
+[Help] > [Keymap Reference] から自分が選択している Keymap のチートシートを選んで印刷し、デスクサイドに置いておくことを推奨します。
+
+また、キーマップのリファレンスガイドはオンラインで参照できます:
 
 - Rider: https://www.jetbrains.com/help/rider/Reference_Keymap_Rider.html
 - ReSharper: https://www.jetbrains.com/help/resharper/Reference__Keyboard_Shortcuts.html

--- a/localized/ja/00-EssentialShortcuts/0.1-AltEnter.cs
+++ b/localized/ja/00-EssentialShortcuts/0.1-AltEnter.cs
@@ -2,23 +2,53 @@
 {
     // <shortcut id="Show context actions">Alt+Enter</shortcut>
     //
-    // Used to apply quick fixes to inspections ("squigglies"), or apply
-    // context specific actions, depending on location of text caret
+    // QuickFix 機能を使ってみましょう。
     //
-    // Also allows searching and applying all ReSharper commands direct
-    // from the menu.
+    // QuickFix は、Inspections (コード検査機能 = 波線で表示されるところ) や、
+    // 現在のキャレット位置に応じて ReSharper や Rider が提供する機能を
+    // 簡単に (ダイレクトに) 適用することが出来ます。
     //
-    // Icon is displayed in gutter margin on left of editor, e.g. yellow
-    // light bulb to fix warning, red light bulb to fix error, hammer to
-    // apply a context action, etc.
+    // もちろん、メニューから機能を選ぶことで、ReSharper や Rider が提供する
+    // 全ての機能を選択して適用することもできます。
+    //
+    // QuickFix があることは、エディタの左側余白(行番号付近)に表示されます。
+    // 例えば、以下のようなバリエーションがあります。
+    //  - 黄色の電球: 警告の修正
+    //  - 赤色の電球: エラーの修正
+    //  - ハンマー  : コンテキストアクションの適用 (選択箇所特有の機能適用)
+    //  - などなど
+    //
+    // (補足)
+    // 「コンテキスト」という言葉は日本語だと「文脈」と翻訳されますが、
+    // 「その時の状況」といったイメージで理解すると良いでしょう。
+    // ReSharper や Rider は、選択箇所そのものの問題だけでなく、
+    // その時の状況 (前後関係やそこに至る文脈) に応じて
+    // 推奨する改善や修正を提示してくれます。
+    // ソフトウエア業界では、こういった前後関係の文脈や
+    // 時間的連続性を言うときに「コンテキスト」という表現を
+    // 使うことが多いです。
+    // https://ja.wikipedia.org/wiki/%E3%82%B3%E3%83%B3%E3%83%86%E3%82%AF%E3%82%B9%E3%83%88
+    //
 
-    // 1. Apply QuickFix for an inspection
-    //    The class doesn't match ReSharper's naming style
-    //    Place text caret on "squiggly". Note the lightbulb in the margin on the left
-    //    Click the light bulb, or hit <shortcut id="Show context actions">Alt+Enter</shortcut>
-    //    Select "Rename to 'BadlyNamedClass'" to fix
+    // 1. Inspection (コード検査結果) に QuickFix を適用してみます
+    //    設定で定義している命名スタイルと一致しないクラス名があったとします。
+    //    ReSharper や Rider は 波線で教えてくれます。
     //
-    // (More on inspections in section 3)
+    //    badlyNamedClass に波線が引かれていると思います (*1)。
+    //    <shortcut id="Show context actions">Alt+Enter</shortcut> を押すか、
+    //    エディター左側の余白、行番号付近にある電球アイコンをクリックしましょう。
+    //
+    //    "Rename to 'BadlyNamedClass'" とコードスタイルに設定されている
+    //    命名規則に適合した修正が提案されているはずです。選択して修正してみましょう。
+    //
+    //    (*1)
+    //    もし、badlyNamedClass に波線が引かれていない場合は、
+    //    あなたが使っている ReSharper や Rider のコードスタイル設定が、
+    //    この演習が期待している前提と違っている可能性が高いです。
+    //    コードスタイルの設定に関しては以下を参照してください。
+    //    https://www.jetbrains.com/resharper/features/code_formatting.html
+    //
+    // (Inspections (コード検査) については Section 3 で詳しく説明します)
     public class badlyNamedClass
     {
     }
@@ -27,20 +57,42 @@
     {
         public static string FormatString(string arg)
         {
-            // 2. Apply context action
-            //    Place text caret on "arg"
-            //    Note the hammer action - a context action is available (no squiggly!)
-            //    Hit <shortcut id="Show context actions">Alt+Enter</shortcut>, select "To String.Format invocation"
+            // 2. コンテキストアクションを適用してみます
+            //    下の "arg" を選択してキャレットを置いてください。
+            //    ハンマーのアイコンが表示されましたか？
+            //    コンテキストアクションを使うことが出来ます(波線は出ませんので注意！)。
+            //    <shortcut id="Show context actions">Alt+Enter</shortcut> を押して、
+            //    "To String.Format invocation" を選択してください。
+            //    String.Format 形式に簡単に修正できます。
+            //
+            //    (注意)
+            //    C#での文字列操作は気付かずパフォーマンス悪化に陥ることが多いです。
+            //    言語仕様を理解していないと、メモリ消費、実行速度の２つの面で課題が出ます。
+            //    メモリ消費の観点では '+' 演算は使うべきではありません。
+            //    StringBuilder 、または内部的に StringBuilder を使っている
+            //    文字列補完機能 '$' を使うべきです。
+            //    もし、実行速度にこだわるのであればもう少し実装方式を考える必要が出てくるでしょう。
+            //
+            //    String 型と StringBuilder 型 の違い
+            //    https://docs.microsoft.com/ja-jp/dotnet/api/system.text.stringbuilder?view=net-5.0#the-string-and-stringbuilder-types
+            //
+            //    Performance Of String Concatenation In C# (C#における文字列結合の性能考察)
+            //    https://dotnetcoretutorials.com/2020/02/06/performance-of-string-concatenation-in-c/
+            //
             return "Hello" + arg + "World";
         }
     }
 
-    // 3. Go to action
-    //    Place text caret on class name below
-    //    <shortcut id="Show context actions">Alt+Enter</shortcut>, note magnifying glass
-    //    Click magnifying glass, start typing "rename"
-    //    Or, just start typing "rename" from menu
-    //    Filters ReSharper commands and applies
+    // 3. Go to action 機能を使ってみます。
+    //    下のクラス名のどこかにキャレットを置き、
+    //    <shortcut id="Show context actions">Alt+Enter</shortcut> を押します。
+    //
+    //    コンテキストメニューが表示されている状態で 'rename' とタイプし、
+    //    たくさんの機能からフィルターして表示される 'Rename...' を選択します。
+    //
+    //    このように、 ReSharper や Rider は、
+    //    様々な場所で直接タイプすることで機能をフィルターし、
+    //    直接呼び出すことが出来ます。
     public class GoToAction
     {
     }

--- a/localized/ja/00-EssentialShortcuts/0.2-GoToEverything.md
+++ b/localized/ja/00-EssentialShortcuts/0.2-GoToEverything.md
@@ -1,9 +1,13 @@
-﻿# Essential Shortcuts - Search Everywhere
+﻿# 必須ショートカット - Search Everywhere (どこでも検索)
 
-Search everywhere by name combines go to type, symbol, actions and file in one menu.
+Search Everywhere (どこでも検索) という、必ず覚えて欲しい必須機能のショートカットがあります。
+名前であらゆる場所を検索し、タイプ、シンボル、アクション、ファイルへの移動を全てここから行うことができます。
 
-<shortcut id="Search Everywhere">Ctrl+T</shortcut>
+| IDE種類    | ショートカット                                                            |
+| :---      | :---                                                                    |
+| ReSharper | <shortcut id="Search Everywhere">Ctrl+T</shortcut>                      |
+| Rider     | <shortcut id="Search Everywhere">Shift, Shift (Double Shift)</shortcut> |
 
-`Escape` to cancel.
+`Escape` でキャンセルできます。
 
-Covered in more detail in next section
+詳細は次のセクションで説明します。

--- a/localized/ja/00-EssentialShortcuts/0.3-ContextualMenus.cs
+++ b/localized/ja/00-EssentialShortcuts/0.3-ContextualMenus.cs
@@ -1,65 +1,72 @@
 ﻿namespace EssentialShortcuts
 {
-    // Navigate To menu
+    // Navigate To メニューを使ってみます。
     //
-    // Displays a contextual menu of options you can use to navigate to from
-    // your current location
+    // 現在の場所から移動したい時に利用できるコンテキストメニューを表示します。
+    // これ１つ覚えておけば目的ごとの個別ショートカットを憶える必要がない便利なナビゲーション機能です。
     //
-    // Very useful way of navigating without having to learn ALL of the shortcuts!
+    // <shortcut id="Navigate To...">Ctrl+Shift+G (Rider Default Keymap)</shortcut>
+    // <shortcut id="Navigate To...">Alt+` (Rider VisualStudio Keymap)</shortcut>
     //
-    // <shortcut id="Navigate To…">Alt+` (VS)</shortcut>
+    // 下の例で試してみましょう。２つの方法があります。
+    // クラス名にキャレットを置き、
+    // 1. 上で示したショートカットで 'Navigate to...' を起動します。
+    // 2. <shortcut id="Show context actions">Alt+Enter</shortcut> を押し、'Navigate To' とタイプします。
     //
-    // 1. Place text caret on class name, invoke menu
-    // 2. <shortcut id="Show context actions">Alt+Enter</shortcut>on class name, start typing (e.g. "Navigate To", "Extension methods")
+    // いずれの場合も表示されたコンテキストメニューで任意のワードをタイプすると、その内容で機能がフィルターできます。
+    // 例えば、 'Navigate to...' を起動したコンテキストメニューで 'Extension methods' とタイプしてみてください。
     //
-    // (Most options not useful with this example. Covered in more detail in next section)
+    // (ここで表示されるほとんどの選択肢はこの演習例では意味をなしません。後のセクションで詳しく説明します。)
     public class NavigateTo
     {
     }
 
 
-    // Refactor This menu
+    // Refactor This メニューを使ってみます。
     //
-    // Displays a contextual menu of options for refactoring available at the current location
+    // 現在の場所で利用可能なリファクタリングのメニューを表示します。
+    // これも１つ覚えておけば目的ごとの個別ショートカットを憶える必要がない便利な機能です。
     //
-    // Very useful for invoking refactorings without requiring to know ALL shortcuts
+    // <shortcut id="Refactor This...">Ctrl+Alt+Shift+T (Rider Default Keymap)</shortcut>
+    // <shortcut id="Refactor This...">Ctrl+Shift+R (Rider VisualStudio Keymap)</shortcut>
     //
-    // <shortcut id="Refactor This...">Ctrl+Shift+R (VS + IntelliJ)</shortcut>
+    // クラス名にキャレットを置き、
+    // 3. 上で示したショートカットで 'Refactor This' を起動します。
+    //    rename を選択し、クラス名を rename してみましょう。
+    // 4. <shortcut id="Show context actions">Alt+Enter</shortcut> を押し、'Refactor This' とタイプします。
+    //    続けて 'Rename' とタイプして rename してみましょう。
     //
-    // 3. Place text caret on class name, invoke menu
-    //    Select rename, rename class
-    // 4. <shortcut id="Show context actions">Alt+Enter</shortcut> on class name, start typing (e.g. "Refactor This", "Rename")
-    //
-    // Covered in more detail in next section
+    // (詳細は次のセクションで説明します。)
     public class RefactorThis
     {
     }
 
 
-    // Generate Code menu
+    // Generate Code メニューを使ってみます。
     //
-    // Displays a contextual menu of options for generating code available at the current location
+    // 現在の場所で利用可能なコード生成のメニューを表示します。
     //
-    // <shortcut id="Generate...">Alt+Insert (in text editor)</shortcut>
+    // <shortcut id="Generate...">Alt+Insert (in text editor / Rider Default Keymap)</shortcut>
+    // <shortcut id="Generate...">Ctrl+N (in text editor / Rider VisualStudio Keymap)</shortcut>
     //
-    // Covered in more detail in the Editing section
+    // (詳細は Editing のセクションで説明します。)
     public class GenerateCode
     {
     }
 
-    // Inspect This menu
+    // Inspect This メニューを使ってみます。
     //
-    // Displays a contextual menu of options for analysing code and control flow
-    // at the current location
+    // 現在の場所で利用可能なコード解析とコントロールフローを分析するためのメニューを表示します。
+    // これ１つ覚えておけば変数解析の個別ショートカットを憶える必要がない便利な機能です。
     //
-    // Very useful for invoking value analysis without learning ALL shortcuts!
+    // <shortcut id="Inspect This...">Ctrl+Shift+Alt+A (Common)</shortcut>
     //
-    // <shortcut id="Inspect This...">Ctrl+Shift+Alt+A (VS + IntelliJ)</shortcut>
+    // クラス名にキャレットを置き、
+    // 5. 上で示したショートカットで 'Inspect This...' を起動します。
+    // 6. <shortcut id="Show context actions">Alt+Enter</shortcut> を押し、 'Inspect This' とタイプします。
+    //    続けて 'TypeHierarchy' とタイプして 継承関係を確認してみましょう。
     //
-    // 4. Place text caret on class name, invoke menu
-    // 5. <shortcut id="Show context actions">Alt+Enter</shortcut> on class name, start typing (e.g. "Inspect This", "Hierarchies")
-    //
-    // (Most options not useful with this example. Covered in more detail in later section)
+    // (ここで表示されるほとんどの選択肢はこの演習例では意味をなしません。後のセクションで詳しく説明します。)
     public class InspectThis
     {
     }


### PR DESCRIPTION
# Summary

- This is the Japanese localized version of 00-EssentialShortcuts.
- The shortcut keys have been improved where they were not fully described.


# Issue

https://github.com/JetBrains/resharper-rider-samples/issues/20
Proposal for creating a Japanese localized version 


# How did I test it?

- I have only conducted self-verification using a translation tool.
- If you have a reliable Japanese person, I would like to ask for a third-party review.

__NOTE__
- Some parts have been "free/loose translation".
- I have filled in the gaps between the lines from a Japanese developer's point of view and translated them into what I consider to be more appropriate expressions.

Have a good weekend (^_-)-☆
