### PR TITLE
(#20) translate into Japanese @ 01-Navigation/5-Navigate_class_hierarchies

### DIFF
--- a/localized/ja/01-Navigation/5-Navigate_class_hierarchies/5.1-Go_to_implementation.cs
+++ b/localized/ja/01-Navigation/5-Navigate_class_hierarchies/5.1-Go_to_implementation.cs
@@ -2,29 +2,65 @@
 
 namespace JetBrains.ReSharper.Koans.Navigation
 {
-    // Go to Implementation
+    // Go to Implementation (ReSharper) / Implementations(s) (Rider)
     //
-    // Navigates to the implementation of the type. For most types, navigates to definition.
-    // For interfaces, navigates to implementations of the interface, for base classes,
-    // navigates to derived instances
+    // その型の実装に移動します。ほとんどの型では、定義に移動します。
+    // インターフェイスの場合は、インターフェイスの実装、基底クラス、派生クラスに移動します。
     //
-    // <shortcut id="Implementation(s)">Ctrl+F12</shortcut>
+    // ReSharper の場合は１つの機能で、状況によって候補リストが表示されたり、
+    // 実装に直接ジャンプしたりと挙動が変わります。
+    //
+    // Rider の場合、リスト表示と直接ジャンプは別の機能としてアサインされています。
+    //
+    // <shortcut id="Go to implementation">Ctrl+F12   or Ctrl+Click     (ReSharper VisualStudio Keymap)</shortcut>
+    // <shortcut id="Go to implementation">Ctrl+B     or Ctrl+Click     (Rider Default IntelliJ Keymap)</shortcut>
+    // <shortcut id="Implementation(s)">   Ctrl+Alt+B or Ctrl+Alt+Click (Rider Default IntelliJ Keymap)</shortcut>
+    //
 
     public class GoToImplementation
     {
         public void Method()
         {
-            // 1. Put the caret on ICustomer and Go To Implementation
-            //    Get the choice of Customer, SilverCustomer and GoldCustomer
-            //    Customer is bold because it's a direct implementation of ICustomer
-            //    SilverCustomer and GoldCustomer are indirect implementations
-            //    (because they derive from Customer)
-            // 2. Put the caret on ICustomer and Go To Implementation
-            //    Filter by typing, middle matching, wildcards and CamelHumps
+            // 1. ICustomer を選択してキャレットを置き、この機能を試してみましょう。
+            //      ReSharper: Go to implementation
+            //      Rider    : Implementation(s)
+            //
+            // <shortcut id="Go to implementation">Ctrl+F12   or Ctrl+Click     (ReSharper VisualStudio Keymap)</shortcut>
+            // <shortcut id="Implementation(s)">   Ctrl+Alt+B or Ctrl+Alt+Click (Rider Default IntelliJ Keymap)</shortcut>
+            //
+            //    Customer, SilverCustomer, GoldCustomer が候補に表示されましたか？
+            //    Customer は ICustomer の直接の実装であるので、太字で表示されます。
+            //    SilverCustomer と GoldCustomer は間接的な実装です ( Customer を経由して派生しているため )。
+            //
             ICustomer customer = GetCustomer();
 
-            // 3. Put the caret on the Customer and Go To Implementation
-            //    Takes you straight to the implementation of the constructor
+            // 2. 再び ICustomer を選択してキャレットを置き、この機能を開いてみてください。
+            //      ReSharper: Go to implementation
+            //      Rider    : Implementation(s)
+            //
+            // <shortcut id="Go to implementation">Ctrl+F12   or Ctrl+Click     (ReSharper VisualStudio Keymap)</shortcut>
+            // <shortcut id="Implementation(s)">   Ctrl+Alt+B or Ctrl+Alt+Click (Rider Default IntelliJ Keymap)</shortcut>
+            //
+            //    リストのポップアップ画面が出たら、タイプしてフィルターしてみましょう。
+            //    中間一致、ワイルドカードや CamelHumps (略語入力) を使ってみましょう。
+            //
+            //      ex.
+            //         CamelHumps (略語入力)
+            //          gc -> GoldCustomer
+            //                ~   ~
+            //          sc -> SilverCustomer
+            //                ~     ~
+            //
+
+            // 3. 今度は Customer を選択してキャレットを置き、この機能を開いてみてください。
+            //      ReSharper: Go to implementation
+            //      Rider    : Go to implementation
+            //
+            // <shortcut id="Go to implementation">Ctrl+F12   or Ctrl+Click     (ReSharper VisualStudio Keymap)</shortcut>
+            // <shortcut id="Go to implementation">Ctrl+B     or Ctrl+Click     (Rider Default IntelliJ Keymap)</shortcut>
+            //
+            //    コンストラクタの実装に直接ジャンプできます。
+            //
             var customer2 = new Customer("id", "Daisy");
         }
 

--- a/localized/ja/01-Navigation/5-Navigate_class_hierarchies/5.2-Go_to_derived_symbols.cs
+++ b/localized/ja/01-Navigation/5-Navigate_class_hierarchies/5.2-Go_to_derived_symbols.cs
@@ -3,31 +3,56 @@ using JetBrains.ReSharper.Koans.Navigation.ExampleCode;
 
 namespace JetBrains.ReSharper.Koans.Navigation
 {
-    // Go to Derived Symbols (Go to Implementation(s))
+    // Go to Derived Symbols (ReSharper) / Implementation(s) (Rider)
     //
-    // <shortcut id="Go to Implementation(s)">Alt+End (VS)</shortcut>
+    // <shortcut id="Go to derived symbols">Alt+End                      (ReSharper VisualStudio Keymap)</shortcut>
+    // <shortcut id="Implementation(s)">    Ctrl+Alt+B or Ctrl+Alt+Click (Rider Default IntelliJ Keymap)</shortcut>
     //
 
     public class GoToDerivedSymbols
     {
         public void Method()
         {
-            // 1. Put the caret on ICustomer and Go To Derived Symbols
-            //    Get the choice of Customer, SilverCustomer and GoldCustomer
-            //    Customer is bold because it's a direct implementation of ICustomer
-            //    SilverCustomer and GoldCustomer are indirect implementations
-            //    (because they derive from Customer)
-            // 2. Put the caret on ICustomer and Go To Implementation
-            //    Filter by typing, middle matching, wildcards and CamelHumps
+            // 1. ICustomer を選択してキャレットを置き、この機能を試してみましょう。
+            //      ReSharper: Go to derived symbols
+            //      Rider    : Implementation(s)
+            //
+            //    Customer, SilverCustomer, GoldCustomer が候補に表示されましたか？
+            //    Customer は ICustomer の直接の実装であるので、太字で表示されます。
+            //    SilverCustomer と GoldCustomer は間接的な実装です ( Customer を経由して派生しているため )。
+            //
             ICustomer customer = GetCustomer();
 
-            // 3. Put the caret on the Customer and Go To Derived Symbols
-            //    Shows GoldCustomer and SilverCustomer (note difference with
-            //    Go To Implementation)
+            // 2. 再び ICustomer を選択してキャレットを置き、この機能を開いてみてください。
+            //      ReSharper: Go to derived symbols
+            //      Rider    : Implementation(s)
+            //
+            //    リストのポップアップ画面が出たら、タイプしてフィルターしてみましょう。
+            //    中間一致、ワイルドカードや CamelHumps (略語入力) を使ってみましょう。
+            //
+            //      ex.
+            //         CamelHumps (略語入力)
+            //          gc -> GoldCustomer
+            //                ~   ~
+            //          sc -> SilverCustomer
+            //                ~     ~
+            //
+
+            // 3. 今度は Customer を選択してキャレットを置き、この機能を開いてみてください。
+            //      ReSharper: Go to derived symbols
+            //      Rider    : Implementation(s)
+            //
+            //    GoldCustomer と SilverCustomer が表示されましたか？
+            //    ( Implementation(s) との挙動の違いに注目してください )
+            //
             var customer2 = new Customer("id", "Daisy");
 
-            // 4. Put the caret on PercentageDiscount and Go To Derived Symbols
-            //    Shown overrides of virtual property in SilverCustomer and GoldCustomer
+            // 4. PercentageDiscount を選択してキャレットを置き、この機能を開いてみてください。
+            //      ReSharper: Go to derived symbols
+            //      Rider    : Implementation(s)
+            //
+            //    SilverCustomer および GoldCustomer の オーバーライド・メソッドが候補に表示されます。
+            //
             Console.WriteLine(customer2.PercentageDiscount);
         }
 

--- a/localized/ja/01-Navigation/5-Navigate_class_hierarchies/5.3-Go_to_base_symbols.cs
+++ b/localized/ja/01-Navigation/5-Navigate_class_hierarchies/5.3-Go_to_base_symbols.cs
@@ -3,27 +3,30 @@ using JetBrains.ReSharper.Koans.Navigation.ExampleCode;
 
 namespace JetBrains.ReSharper.Koans.Navigation
 {
-    // Go to Derived Symbols
+    // Go to Base Symbols
     //
-    // <shortcut id="Go to Super Method">Alt+Home (VS)</shortcut>
+    // <shortcut id="Go to base symbols">Alt+Home   (ReSharper VisualStudio Keymap)</shortcut>
+    // <shortcut id="Go to base symbols">Ctrl+U     (Rider Default IntelliJ Keymap)</shortcut>
     //
 
     public class GoToBaseSymbols
     {
         public void Method()
         {
-            // 1. Put the caret on Customer and Go To Base Symbols
-            //    Navigated to ICustomer
+            // 1. Customer を選択してキャレットを置き、この機能を試してみましょう。
+            //    ICustomer に移動できましたか？
             Customer customer = GetCustomer();
 
-            // 2. Put the caret on SilverCustomer and Go To Base Symbols
-            //    Navigated to Customer.
-            //    Always navigates one level up the hierarchy, rather than
-            //    Go To Derived Symbols, which can navigate many levels down
+            // 2. SilverCustomer を選択してキャレットを置き、この機能を試してみましょう。
+            //    Customer に移動できましたか？
+            //    ”Go to derived symbols” と異なり、常に１つ上の継承レベルに移動しますが、
+            //    何段階も先の階層に移動することもできます。
+            //
             var customer2 = new SilverCustomer("id", "Tim");
 
-            // 3. Put the caret on PercentageDiscount and Go To Base Symbols
-            //    Navigated to virtual property Customer.PercentageDiscount
+            // 3. PercentageDiscount を選択してキャレットを置き、この機能を試してみましょう。
+            //    基底クラスの仮想プロパティが候補に表示されます。
+            //
             Console.WriteLine(customer2.PercentageDiscount);
         }
 

--- a/localized/ja/01-Navigation/5-Navigate_class_hierarchies/ExampleCode/ICustomer.cs
+++ b/localized/ja/01-Navigation/5-Navigate_class_hierarchies/ExampleCode/ICustomer.cs
@@ -1,14 +1,27 @@
 ﻿namespace JetBrains.ReSharper.Koans.Navigation.ExampleCode
 {
+    // 戻る
+    // <shortcut id="Navigate back">Ctrl+- (minus) (ReSharper VisualStudio Keymap)</shortcut>
+    // <shortcut id="Navigate back">Ctrl+Alt+Left  (Rider Default IntelliJ Keymap)</shortcut>
     public interface ICustomer
     {
         string Id { get; }
         string Name { get; }
+
+        // 戻る
+        // <shortcut id="Navigate back">Ctrl+- (minus) (ReSharper VisualStudio Keymap)</shortcut>
+        // <shortcut id="Navigate back">Ctrl+Alt+Left  (Rider Default IntelliJ Keymap)</shortcut>
         int PercentageDiscount { get; }
     }
 
+    // 戻る
+    // <shortcut id="Navigate back">Ctrl+- (minus) (ReSharper VisualStudio Keymap)</shortcut>
+    // <shortcut id="Navigate back">Ctrl+Alt+Left  (Rider Default IntelliJ Keymap)</shortcut>
     public class Customer : ICustomer
     {
+        // 戻る
+        // <shortcut id="Navigate back">Ctrl+- (minus) (ReSharper VisualStudio Keymap)</shortcut>
+        // <shortcut id="Navigate back">Ctrl+Alt+Left  (Rider Default IntelliJ Keymap)</shortcut>
         public Customer(string id, string name)
         {
             Id = id;
@@ -18,9 +31,16 @@
 
         public string Name { get; private set; }
         public string Id { get; private set; }
+
+        // 戻る
+        // <shortcut id="Navigate back">Ctrl+- (minus) (ReSharper VisualStudio Keymap)</shortcut>
+        // <shortcut id="Navigate back">Ctrl+Alt+Left  (Rider Default IntelliJ Keymap)</shortcut>
         public virtual int PercentageDiscount { get; private set; }
     }
 
+    // 戻る
+    // <shortcut id="Navigate back">Ctrl+- (minus) (ReSharper VisualStudio Keymap)</shortcut>
+    // <shortcut id="Navigate back">Ctrl+Alt+Left  (Rider Default IntelliJ Keymap)</shortcut>
     public class SilverCustomer : Customer
     {
         public SilverCustomer(string id, string name)
@@ -28,12 +48,18 @@
         {
         }
 
+        // 戻る
+        // <shortcut id="Navigate back">Ctrl+- (minus) (ReSharper VisualStudio Keymap)</shortcut>
+        // <shortcut id="Navigate back">Ctrl+Alt+Left  (Rider Default IntelliJ Keymap)</shortcut>
         public override int PercentageDiscount
         {
             get { return 10; }
         }
     }
 
+    // 戻る
+    // <shortcut id="Navigate back">Ctrl+- (minus) (ReSharper VisualStudio Keymap)</shortcut>
+    // <shortcut id="Navigate back">Ctrl+Alt+Left  (Rider Default IntelliJ Keymap)</shortcut>
     public class GoldCustomer : Customer
     {
         public GoldCustomer(string id, string name)
@@ -41,6 +67,9 @@
         {
         }
 
+        // 戻る
+        // <shortcut id="Navigate back">Ctrl+- (minus) (ReSharper VisualStudio Keymap)</shortcut>
+        // <shortcut id="Navigate back">Ctrl+Alt+Left  (Rider Default IntelliJ Keymap)</shortcut>
         public override int PercentageDiscount
         {
             get { return 25; }


### PR DESCRIPTION
# Summary

- This is the Japanese localized version of `01-Navigation/5-Navigate_class_hierarchies` .


# Issue

https://github.com/JetBrains/resharper-rider-samples/issues/20
Proposal for creating a Japanese localized version 


# How did I test it?

- I have only conducted self-verification using a translation tool.
- If you have a reliable Japanese person, I would like to ask for a third-party review.

__NOTE__
- Some parts have been "free/loose translation".
- I have filled in the gaps between the lines from a Japanese developer's point of view and translated them into what I consider to be more appropriate expressions.

Thanks.
